### PR TITLE
Force use of ruby 2.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby "2.3.3"
+
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
   "https://github.com/#{repo_name}.git"


### PR DESCRIPTION
So we know that everybody is working on one version
We saw during the course that 2.3.3 is the most reliable recent version